### PR TITLE
Block robots on draft preview

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,9 @@ You can find full plugin description [here](https://wpserved.com/plugins/post-dr
 You can find plugin's source files on our GitHub repo [page](https://github.com/wpserved/post-draft-preview).
 
 == Changelog ==
+= 1.0.2 =
+* Discourage robots from visiting draft pages
+
 = 1.0.1 =
 * Fix problem with the "Disable PDP" button
 * Update the tested up WP version

--- a/src/Post/Post.php
+++ b/src/Post/Post.php
@@ -13,6 +13,7 @@ class Post
     private ?PostEdit $PostEdit = null;
     private ?Meta $meta = null;
     private ?Draft $draft = null;
+    private ?Robots $robots = null;
 
     public function __construct()
     {
@@ -20,6 +21,7 @@ class Post
         $this->PostEdit = createClass(PostEdit::class, [$this]);
         $this->meta = createClass(Meta::class);
         $this->draft = createClass(Draft::class, [$this]);
+        $this->robots = createClass(Robots::class, [$this]);
     }
 
     public function getMeta(): Meta

--- a/src/Post/Robots.php
+++ b/src/Post/Robots.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PostDraftPreview\Post;
+
+class Robots
+{
+    private ?Post $post = null;
+
+    public function __construct(Post $post)
+    {
+        $this->post = $post;
+    }
+
+    /**
+     * @filter wp_robots
+     */
+    public function blockRobots(array $robots): array
+    {
+        if (! is_singular()) {
+            return $robots;
+        }
+
+        $post = get_post();
+
+        if ('draft' !== $post->post_status) {
+            return $robots;
+        }
+
+        if (1 !== $this->post->getMeta()->getStatus($post->ID)) {
+            return $robots;
+        }
+
+        $robots['noindex'] = true;
+        $robots['nofollow'] = true;
+
+        return $robots;
+    }
+}


### PR DESCRIPTION
This adds a small submodule for managing robots meta tags on the draft preview page.

It checks if the displayed post is a singular, of status "draft" and has the correct PDP meta status. If all the conditions are fulfilled, it adds "noindex" and "nofollow" to the meta tag.