### PR TITLE
Fix method param

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,9 @@ You can find full plugin description [here](https://wpserved.com/plugins/post-dr
 You can find plugin's source files on our GitHub repo [page](https://github.com/wpserved/post-draft-preview).
 
 == Changelog ==
+= 1.0.2 =
+* Fix checking for draft status metadata
+
 = 1.0.1 =
 * Fix problem with the "Disable PDP" button
 * Update the tested up WP version

--- a/src/Post/Meta.php
+++ b/src/Post/Meta.php
@@ -11,7 +11,7 @@ class Meta
 
     private function setHash(string $hash, int $postID): void
     {
-        if (@metadata_exists(get_post_type($postID), $postID, 'pdp_hash')) {
+        if (@metadata_exists('post', $postID, 'pdp_hash')) {
             update_post_meta($postID, 'pdp_hash', $hash);
             return;
         }
@@ -25,11 +25,11 @@ class Meta
 
     public function setStatus(int $postID, int $status): void
     {
-        if (1 === $status && ! @metadata_exists(get_post_type($postID), $postID, 'pdp_hash')) {
+        if (1 === $status && ! @metadata_exists('post', $postID, 'pdp_hash')) {
             $this->setHash($this->generateRandomString() . $postID, $postID);
         }
 
-        if (@metadata_exists(get_post_type($postID), $postID, 'pdp_status')) {
+        if (@metadata_exists('post', $postID, 'pdp_status')) {
             update_post_meta($postID, 'pdp_status', $status);
             return;
         }


### PR DESCRIPTION
This fixes a bug that makes disabling the PDP impossible.

**Steps to reproduce:**
1. Add a new post/page. ✅
2. Save the post as a draft. ✅
3. Enable PDP. ✅
4. Disable PDP. ❌

**The bug description:**
Methods of the PostDraftPreview\Post\Meta class are responsible for managing the metadata of the posts. The metadata_exists() function that is utilized by some of them, accepts a post type as the first parameter. It appears that the function docs are a bit misleading because it does not refer to the post type itself but to the database table. Shortly, if you want to check if the metadata exists for custom post type (let's assume there is a CPT "books" registered), you don't pass the "books" as the parameter. Instead, you want to pass "post", because the metadata is stored in the wp_**post**meta table. A bit strange, but I tested it and it looks like this is the desired way of using it.

**The solution:**
Replacing the post type with a simple string 'post' solves the issue, as the plugin works with posts only. Saying "posts only" I mean all the default and custom post types, pages, etc.

**Testing environment:**
WordPress: Version 6.2.2
Post Draft Preview: Version 1.2.0.1