### PR TITLE
Check for posts before removing the filter

### DIFF
--- a/src/Post/Draft.php
+++ b/src/Post/Draft.php
@@ -50,12 +50,23 @@ class Draft
 
     public function displayDraftPost(?array $posts, \WP_Query $query): ?array
     {
+        if (! empty($posts)) {
+            return $posts;
+        }
+
         remove_filter('the_posts', 'display_draft_post', 10, 2);
         return $query->_draft_post;
     }
 
     public function getPublicDraftPreviewUrl(\WP_Post $post): string
     {
-        return ! empty($this->post->getMeta()->getHash($post->ID)) ? add_query_arg('hash', $this->post->getMeta()->getHash($post->ID), get_permalink($post)) : '';
+        $queryArgs = [
+            'hash' => $this->post->getMeta()->getHash($post->ID),
+            'preview' => 'true',
+        ];
+
+        $previewUrl = add_query_arg($queryArgs, get_permalink($post));
+
+        return ! empty($this->post->getMeta()->getHash($post->ID)) ? $previewUrl : '';
     }
 }


### PR DESCRIPTION
The issue fix contains two changes:

1. The preview URL has to contain the additional param `preview` with the value of `true`, to set proper query vars later, when posts are being retrieved.
2. The `the_posts` filter requires additional checking for the `posts` argument. It filtered ACF queries because lack of this check and the page could not reach the ACF data from the database.

@coditive-pawel-m, I did some testing and everything worked fine, but I would appreciate it if you do additional quick tests on your side.